### PR TITLE
Single quote escaping consistency

### DIFF
--- a/src/main/java/freemarker/ext/beans/ResourceBundleModel.java
+++ b/src/main/java/freemarker/ext/beans/ResourceBundleModel.java
@@ -165,10 +165,11 @@ public class ResourceBundleModel
         String key = unwrap((TemplateModel)it.next()).toString();
         try
         {
-            if(!it.hasNext())
-            {
-                return wrap(((ResourceBundle)object).getObject(key));
-            }
+            // Always use MessageFormat to keep single quote escaping consistent
+            //if(!it.hasNext())
+            //{
+            //    return wrap(((ResourceBundle)object).getObject(key));
+            //}
     
             // Copy remaining arguments into an Object[]
             int args = arguments.size() - 1;


### PR DESCRIPTION
Always use MessageFormat to keep single quote escaping consistent.
I believe I can also be extending to {.
