### PR TITLE
A few minor improvements for debugger client

### DIFF
--- a/src/main/java/freemarker/debug/impl/DebuggerServer.java
+++ b/src/main/java/freemarker/debug/impl/DebuggerServer.java
@@ -82,6 +82,8 @@ class DebuggerServer
     private final byte[] password;
     private final int port;
     private final Serializable debuggerStub;
+    private boolean stop = false;
+    private ServerSocket serverSocket;
     
     public DebuggerServer(Serializable debuggerStub)
     {
@@ -112,10 +114,10 @@ class DebuggerServer
     {
         try
         {
-            ServerSocket ss = new ServerSocket(port);
-            for(;;)
+            serverSocket = new ServerSocket(port);
+            while(!stop)
             {
-                Socket s = ss.accept();
+                Socket s = serverSocket.accept();
                 new Thread(new DebuggerAuthProtocol(s)).start();
             }
         }
@@ -163,5 +165,21 @@ class DebuggerServer
             }
         }
 
+    }
+
+    public void stop()
+    {
+        this.stop = true;
+        if(serverSocket != null)
+        {
+            try
+            {
+                serverSocket.close();
+            }
+            catch(IOException e)
+            {
+                logger.error("Unable to close server socket.", e);
+            }
+        }
     }
 }

--- a/src/main/java/freemarker/debug/impl/DebuggerService.java
+++ b/src/main/java/freemarker/debug/impl/DebuggerService.java
@@ -107,6 +107,13 @@ public abstract class DebuggerService
     throws
         RemoteException;
 
+    abstract void shutdownSpi();
+
+    public static void shutdown()
+    {
+        instance.shutdownSpi();
+    }
+
     private static class NoOpDebuggerService extends DebuggerService
     {
         List getBreakpointsSpi(String templateName)
@@ -120,6 +127,10 @@ public abstract class DebuggerService
         }
         
         void registerTemplateSpi(Template template)
+        {
+        }
+
+        void shutdownSpi()
         {
         }
     }

--- a/src/main/java/freemarker/debug/impl/RmiDebuggedEnvironmentImpl.java
+++ b/src/main/java/freemarker/debug/impl/RmiDebuggedEnvironmentImpl.java
@@ -90,6 +90,10 @@ implements
                 value = new DebugConfigurationModel((Configuration)key);
             }
         }
+        if(value != null)
+        {
+            storage.put(key, value);
+        }
         return value;
     }
 


### PR DESCRIPTION
I'm writing a freemarker debugger for Liferay IDE (Eclipse plugins) to debug freemarker templates executed inside of Liferay Portal Server.  See tickets here:
http://issues.liferay.com/browse/IDE-971
http://issues.liferay.com/browse/LPS-35774

During development of our debugger client we had to make several changes to get things to work for our Eclipse debugger.  I've pushed those changes to my fork and wanted to see if the freemarker project maintainers were interested in them.

-Added support for closing debug server socket
-Added support for shutting down debugger service
-Fixed bug with RemoteObject getting garbage collected
-Narrowed templateElement matching for breakpoints
