### PR TITLE
Modified debugger to allow for clients to emulate stepping

### DIFF
--- a/src/main/java/freemarker/core/DebugBreak.java
+++ b/src/main/java/freemarker/core/DebugBreak.java
@@ -62,16 +62,19 @@ import freemarker.template.TemplateException;
  */
 public class DebugBreak extends TemplateElement
 {
-    public DebugBreak(TemplateElement nestedBlock)
+    private int lineNumber;
+
+    public DebugBreak(TemplateElement nestedBlock, int lineNumber)
     {
         this.nestedBlock = nestedBlock;
         nestedBlock.parent = this;
+        this.lineNumber = lineNumber;
         copyLocationFrom(nestedBlock);
     }
     
     protected void accept(Environment env) throws TemplateException, IOException
     {
-        if(!DebuggerService.suspendEnvironment(env, this.getTemplate().getName(), nestedBlock.getBeginLine()))
+        if(!DebuggerService.suspendEnvironment(env, this.getTemplate().getName(), this.lineNumber))
         {
             nestedBlock.accept(env);
         }

--- a/src/main/java/freemarker/debug/impl/RmiDebuggerImpl.java
+++ b/src/main/java/freemarker/debug/impl/RmiDebuggerImpl.java
@@ -27,9 +27,12 @@ implements
         this.service = service;
     }
 
-    public void addBreakpoint(Breakpoint breakpoint)
+    public void addBreakpoint(Breakpoint breakpoint) throws RemoteException
     {
-        service.addBreakpoint(breakpoint);
+        if(!service.addBreakpoint(breakpoint))
+        {
+            throw new RemoteException("unable to add breakpoint");
+        }
     }
 
     public Object addDebuggerListener(DebuggerListener listener)


### PR DESCRIPTION
- Added line information to DebugBreak
- Added logic to fail adding a new breakpoint to an
  existing element that is already a DebugBreak
  this is useful for stepping in a client editor
  where the user is expecting to step line-by-line
  but the next line may be still in the same DebugBreak
  So this code will now refuse to insert the new breakpoint
  and throw a remote exception

_Note_ 
This will not allow for setting nested breakpoints, like a breakpoint on a <#if>... and then try to add another breakpoint somewhere inside of that breakpoint, like 

```
<#if>...
...${abc}
</#if>
```

So I understand if you don't wish to merge these changes as it my cripple other debuggers.  We could update the API a bit to allow for nested breakpoints if we wanted to enable both behaviors.
