### PR TITLE
Support boolean parameter types on JSP tags

### DIFF
--- a/src/main/java/freemarker/ext/jsp/JspTagModelBase.java
+++ b/src/main/java/freemarker/ext/jsp/JspTagModelBase.java
@@ -84,6 +84,13 @@ class JspTagModelBase
                         aarg[0] = BeansWrapper.coerceBigDecimal(
                                 (BigDecimal)arg, m.getParameterTypes()[0]);
                     }
+                    Class[] paramTypes = m.getParameterTypes();
+                    if (paramTypes.length > 0 && aarg[0] instanceof String) {
+                        String strArg = (String) aarg[0];
+                        if (paramTypes[0].isAssignableFrom(Boolean.class) || boolean.class == paramTypes[0]) {
+                            aarg[0] = Boolean.valueOf(strArg);
+                        }
+                    }
                     m.invoke(tag, aarg);
                 }
             }


### PR DESCRIPTION
JSP tag attributes that take boolean parameters (and presumably anything other than Strings) are failing when used via Freemarker. This patch coerces Strings into booleans where necessary.

For reference, the specific tag I had a problem with is the Jawr "script" tag (https://jawr.java.net/docs/taglibs.html) and it's 'useRandomParam' attribute.
