### PR TITLE
Boolean String value is empty string

### DIFF
--- a/src/main/java/freemarker/core/EvalUtil.java
+++ b/src/main/java/freemarker/core/EvalUtil.java
@@ -360,13 +360,13 @@ class EvalUtil
                 return env.formatBoolean(booleanValue, false);
             } else {
                 if (compatMode == 1) {
-                    return booleanValue ? MiscUtil.C_TRUE : "";
+                    return booleanValue ? MiscUtil.C_TRUE : MiscUtil.C_FALSE;
                 } else if (compatMode == 2) {
                     if (tm instanceof BeanModel) {
                         // In 2.1, bean-wrapped booleans where strings, so that has overridden the boolean behavior: 
                         return _BeansAPI.getAsClassicCompatibleString((BeanModel) tm);
                     } else {
-                        return booleanValue ? MiscUtil.C_TRUE : "";
+                        return booleanValue ? MiscUtil.C_TRUE : MiscUtil.C_FALSE;
                     }
                 } else {
                     throw new BugException("Unsupported classic_compatible variation: " + compatMode);


### PR DESCRIPTION
In some cases the String value of a boolean expression is evaluated to "" when the boolean value is false but when the value is true it the string "true" is returned.

Note that I was playing around with FreeMarker for the first time in the context of using the result of the template for computing and not for rendering. The settings I've made to the config are what I believe should be set if you want FreeMarker for computing and not rendering, please correct me here if I got it all wrong. 
I tried reading up on the usage of c? but still I think this is an error, please let me know what you think.

This snippet shows you the issue:

```
public static void main(String[] args) throws IOException, TemplateException {
    final StringTemplateLoader stringLoader = new StringTemplateLoader();

    stringLoader.putTemplate("true_expression", "${ 10 lt 11 }");
    stringLoader.putTemplate("false_expression", " ${ 10 gt 11 }");

    Configuration configuration = new Configuration();
    configuration.setObjectWrapper(new DefaultObjectWrapper());
    configuration.setDefaultEncoding("UTF-8");
    configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
    configuration.setTemplateLoader(stringLoader);

    configuration.setIncompatibleImprovements(new Version(2, 3, 21));
    configuration.setClassicCompatible(true);


    StringWriter sw = new StringWriter();
    Template template = configuration.getTemplate("true_expression");

    template.process(new HashMap<>(), sw);

    StringBuilder sb = new StringBuilder();

    sb.append(sw.getBuffer());

    System.out.println("true expression = " + sb.toString());

    // SAME THING BUT WITH FALSE

    sw = new StringWriter();
    template = configuration.getTemplate("false_expression");

    template.process(new HashMap<>(), sw);

    sb = new StringBuilder();

    sb.append(sw.getBuffer());

    System.out.println("false expression = " + sb.toString());
}
```

output becomes

true expression =  true
false expression =  
