### PR TITLE
Customizability of TemplateCache findTemplateSource(String, Locale)

### DIFF
--- a/src/main/java/freemarker/cache/TemplateCache.java
+++ b/src/main/java/freemarker/cache/TemplateCache.java
@@ -574,7 +574,7 @@ public class TemplateCache
         }
     }
 
-    private Object findTemplateSource(String name, Locale locale)
+    protected Object findTemplateSource(String name, Locale locale)
     throws
         IOException
     {
@@ -607,7 +607,7 @@ public class TemplateCache
         }
     }
 
-    private Object acquireTemplateSource(String path) throws IOException
+    protected Object acquireTemplateSource(String path) throws IOException
     {
         int asterisk = path.indexOf(ASTERISK);
         // Shortcut in case there is no acquisition

--- a/src/main/java/freemarker/template/Configuration.java
+++ b/src/main/java/freemarker/template/Configuration.java
@@ -37,8 +37,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import javax.servlet.ServletContext;
-
 import freemarker.cache.CacheStorage;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.cache.FileTemplateLoader;
@@ -382,13 +380,13 @@ public class Configuration extends Configurable implements Cloneable {
         loadBuiltInSharedVariables();
     }
 
-    private void createTemplateCache() {
+    protected void createTemplateCache() {
         cache = new TemplateCache(getDefaultTemplateLoader(), this);
         cache.clear(); // for fully BC behavior
         cache.setDelay(5000);
     }
     
-    private void recreateTemplateCacheWith(TemplateLoader loader, CacheStorage storage) {
+    protected void recreateTemplateCacheWith(TemplateLoader loader, CacheStorage storage) {
         TemplateCache oldCache = cache;
         cache = new TemplateCache(loader, storage, this);
         cache.clear(); // for fully BC behavior


### PR DESCRIPTION
Make some methods protected so they can be used / overridden in a subclass. This is the only way to change the order in which locale tagged templates are found. (Full locale, country code, language code, no locale)