### PR TITLE
Fixed NPE in case of passing null refs to "c:set" tag

### DIFF
--- a/src/main/java/freemarker/ext/jsp/FreeMarkerJspApplicationContext.java
+++ b/src/main/java/freemarker/ext/jsp/FreeMarkerJspApplicationContext.java
@@ -148,7 +148,7 @@ class FreeMarkerJspApplicationContext implements JspApplicationContext
                 public ValueExpression setVariable(String name, 
                         ValueExpression value) {
                     ValueExpression prev = resolveVariable(name);
-                    pageCtx.setAttribute(name, value.getValue(
+                    pageCtx.setAttribute(name, value==null?null:value.getValue(
                             FreeMarkerELContext.this));
                     return prev;
                 }


### PR DESCRIPTION
This should fix issues arising after an upgrade to JSP 2.1 (and above, I guess).
i.e. there's an issue filed at  https://sourceforge.net/p/freemarker/bugs/204/ 
The problem lies on the fact that ``SetSupport`` relies on ``javax.el.VariableMapper.setVariable(String, ValueExpression)`` supporting ``null`` refs on the last parameter. So at ``org.apache.taglibs.standard.tag.common.core.SetSupport.doEndTag()`` it does things like
```
// Make sure to clear any previous mapping for this
// variable in the variable mapper.
if (scope ==  PageContext.PAGE_SCOPE) {
  VariableMapper vm =
    pageContext.getELContext().getVariableMapper();
  if (vm != null) {
    vm.setVariable(var, null);//PASSING NULL REF HERE
  }
}
```
while the original implementation doesn't provide null handling