### PR TITLE
Added Switch to TemplateException, to retain null value in field "env…

### DIFF
--- a/src/main/java/freemarker/core/InvalidReferenceException.java
+++ b/src/main/java/freemarker/core/InvalidReferenceException.java
@@ -27,7 +27,7 @@ public class InvalidReferenceException extends TemplateException {
     static final InvalidReferenceException FAST_INSTANCE = new InvalidReferenceException(
             "Invalid reference. Details are unavilable, as this should have been handled by an FTL construct. "
             + "If it wasn't, that's problably a bug in FreeMarker.",
-            null);
+            null, false);
     
     private static final String[] TIP = new String[] {
         "If the failing expression is known to be legally refer to something that's sometimes null or missing, "
@@ -62,7 +62,7 @@ public class InvalidReferenceException extends TemplateException {
      * As such, try to avoid this constructor.
      */
     public InvalidReferenceException(Environment env) {
-        super("Invalid reference: The expression has evaluated to null or refers to something that doesn't exist.",
+        this("Invalid reference: The expression has evaluated to null or refers to something that doesn't exist.",
                 env);
     }
 
@@ -72,7 +72,16 @@ public class InvalidReferenceException extends TemplateException {
      * the FreeMarker core.
      */
     public InvalidReferenceException(String description, Environment env) {
-        super(description, env);
+        this(description, env, true);
+    }
+
+    /**
+     * Creates and invalid reference exception that contains no programmatically extractable information about the
+     * blamed expression. As such, try to avoid this constructor, unless need to raise this expression from outside
+     * the FreeMarker core. 
+     */
+    public InvalidReferenceException(String description, Environment env, boolean useCurrentEnvironmentIfEnvIsNull) {
+        super(description, env, useCurrentEnvironmentIfEnvIsNull);
     }
 
     /**

--- a/src/main/java/freemarker/template/TemplateException.java
+++ b/src/main/java/freemarker/template/TemplateException.java
@@ -85,7 +85,18 @@ public class TemplateException extends Exception {
      * @param description the description of the error that occurred
      */
     public TemplateException(String description, Environment env) {
-        this(description, null, env);
+        this(description, env, true);
+    }
+
+    /**
+     * Constructs a TemplateException with the given detail message,
+     * but no underlying cause exception.
+     *
+     * @param description the description of the error that occurred
+     * @param useCurrentEnvironmentIfEnvIsNull use Envirorment.getCurrentEnvironment() if env is null. 
+     */
+    public TemplateException(String description, Environment env, boolean useCurrentEnvironmentIfEnvIsNull) {
+        this(description, null, env, null, null, useCurrentEnvironmentIfEnvIsNull);
     }
 
     /**
@@ -147,12 +158,23 @@ public class TemplateException extends Exception {
             String renderedDescription,
             Throwable cause,            
             Environment env, Expression blamedExpression,
-            _ErrorDescriptionBuilder descriptionBuilder) {
+            _ErrorDescriptionBuilder descriptionBuilder
+            ) {
+        this(renderedDescription, cause, env, blamedExpression, descriptionBuilder, true);
+    }
+    
+    private TemplateException(
+            String renderedDescription,
+            Throwable cause,            
+            Environment env, Expression blamedExpression,
+            _ErrorDescriptionBuilder descriptionBuilder,
+            boolean useCurrentEnvironmentIfEnvIsNull
+            ) {
         // Note: Keep this constructor lightweight.
         
         super(cause);  // Message managed locally.
         
-        if (env == null) env = Environment.getCurrentEnvironment();
+        if (useCurrentEnvironmentIfEnvIsNull && env == null) env = Environment.getCurrentEnvironment();
         this.env = env;
         
         this.blamedExpression = blamedExpression;


### PR DESCRIPTION
Hi,

we have multiple environment Instances in use - and these envirorment may contain much data, as they hold a reference to our data store.

the last one may be reconfigured (the objects are replaced), and then we have the duplicate amount of data in our heap, which will never get garbage collected, as InvalidReferenceException.FAST_INSTANCE is  a static final field, holding the reference to the Enviroment. (Which from what i got from the code also  isn't necessary, and might even be wrong?)

Best,

Georg